### PR TITLE
Use sqlite_master instead of sqlite_schema

### DIFF
--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -28,7 +28,7 @@ export class SqliteIntrospector implements DatabaseIntrospector {
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false }
   ): Promise<TableMetadata[]> {
     let query = this.#db
-      .selectFrom('sqlite_schema')
+      .selectFrom('sqlite_master')
       .where('type', 'in', ['table', 'view'])
       .where('name', 'not like', 'sqlite_%')
       .select('name')


### PR DESCRIPTION
As of sqlite-3.33.0, the internal table formerly known as sqlite_master was aliased to sqlite_schema.

There is a mismatch in the schema name being references in the sqlite inspector, in one query sqlite_schema is used, then directly after sqlite_master is used.  

They renamed sqlite_master to sqlite_schema, but both exist at this point and will for the foreseeable future.

For maximum compatibility use sqlite_master.


Another option could be to do something like this in the inspector:

```ts

const version = await sql`select sqlite_version() as version;`.execute(
	this.#db,
);

const isOld = isVersionLessThan(version.rows[0].version, "3.33.0");

let query = this.#db
	.selectFrom(isOld ? "sqlite_master" : "sqlite_schema")
	.where("type", "in", ["table", "view"])
	.where("name", "not like", "sqlite_%")
	.select("name")
	.orderBy("name")
	.$castTo<{ name: string }>();
```

```ts
function isVersionLessThan(version: string, targetVersion: string): boolean {
	const versionParts = version.split(".");
	const targetVersionParts = targetVersion.split(".");

	for (let i = 0; i < versionParts.length; i++) {
		const versionPart = parseInt(versionParts[i]);
		const targetVersionPart = parseInt(targetVersionParts[i]);

		if (versionPart < targetVersionPart) {
			return true;
		}
	}

	return false;
}

```